### PR TITLE
Fix TS1005 error in declaration.

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -57,7 +57,7 @@ export interface ClientOptions {
   queueDisable?: boolean;
   bindDN?: string;
   bindCredentials?: string;
-  createConnection?: (port: number, host: string, onConnect: () => void, onSocketDefined: (socket: net.Socket) => void, onError: (error: any) => void);
+  createConnection?: (port: number, host: string, onConnect: () => void, onSocketDefined: (socket: net.Socket) => void, onError: (error: any) => void) => void;
 }
 
 export interface SearchOptions {


### PR DESCRIPTION
This PR fixes a TS1005 error (`'=>' expected`) in `lib/index.d.ts`.